### PR TITLE
compat with C++11

### DIFF
--- a/src/find_polynomial_roots_jenkins_traub.cc
+++ b/src/find_polynomial_roots_jenkins_traub.cc
@@ -323,7 +323,7 @@ class JenkinsTraubSolver {
   // nearly equal since the root pairs are complex conjugates. This tolerance
   // measures how much the real values may diverge before consider the quadratic
   // shift to be failed.
-  static const double kRootPairTolerance = 0.01;
+  const double kRootPairTolerance = 0.01;
 };
 
 bool JenkinsTraubSolver::ExtractRoots() {


### PR DESCRIPTION
line 326 is not accepted anymore from C++11.
Here is a suggested portable fix. const could be also replaced by `constexpr`